### PR TITLE
feat: VisitService, VisitController 구현

### DIFF
--- a/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/controller/VisitController.java
+++ b/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/controller/VisitController.java
@@ -1,0 +1,35 @@
+package com.seobusanguyz.reward_demo.controller;
+
+import com.seobusanguyz.reward_demo.dto.VisitDto;
+import com.seobusanguyz.reward_demo.service.VisitService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/visits")
+public class VisitController {
+    private final VisitService service;
+
+    public VisitController(VisitService service) {
+        this.service = service;
+    }
+
+    // 1) 방문 정보 저장 (POST /api/visits)
+    @PostMapping
+    public ResponseEntity<VisitDto> create(@RequestBody VisitDto req) {
+        VisitDto saved = service.save(req.latitude(), req.longitude());
+        URI location = URI.create("/api/visits/" + saved.id());
+        return ResponseEntity
+                .created(location)
+                .body(saved);
+    }
+
+    // 2) 모든 방문 기록 조회 (GET /api/visits)
+    @GetMapping
+    public List<VisitDto> list() {
+        return service.findAll();
+    }
+}

--- a/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/dto/VisitDto.java
+++ b/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/dto/VisitDto.java
@@ -1,0 +1,10 @@
+package com.seobusanguyz.reward_demo.dto;
+
+import java.time.LocalDateTime;
+
+public record VisitDto(
+        Long    id,
+        double  latitude,
+        double  longitude,
+        LocalDateTime timestamp
+) {}

--- a/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/entity/Visit.java
+++ b/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/entity/Visit.java
@@ -27,6 +27,11 @@ public class Visit {
         this.timestamp = timestamp;
     }
 
+    // **추가**: 편의 생성자
+    public Visit(double latitude, double longitude) {
+        this(latitude, longitude, LocalDateTime.now());
+    }
+
     // -- getters / setters --
     public Long getId() { return id; }
 

--- a/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/service/VisitService.java
+++ b/backend/reward-demo/src/main/java/com/seobusanguyz/reward_demo/service/VisitService.java
@@ -1,0 +1,39 @@
+package com.seobusanguyz.reward_demo.service;
+
+import com.seobusanguyz.reward_demo.dto.VisitDto;
+import com.seobusanguyz.reward_demo.entity.Visit;
+import com.seobusanguyz.reward_demo.repository.VisitRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class VisitService {
+    private final VisitRepository repo;
+
+    public VisitService(VisitRepository repo) {
+        this.repo = repo;
+    }
+
+    public VisitDto save(double lat, double lng) {
+        Visit v = new Visit(lat, lng);
+        Visit saved = repo.save(v);
+        return toDto(saved);
+    }
+
+    public List<VisitDto> findAll() {
+        return repo.findAll().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private VisitDto toDto(Visit v) {
+        return new VisitDto(
+                v.getId(),
+                v.getLatitude(),
+                v.getLongitude(),
+                v.getTimestamp()
+        );
+    }
+}


### PR DESCRIPTION
## 변경 사항
- `backend`  
  - `VisitService` 클래스 구현
    **save(double latitude, double longitude)** 메서드 추가
  - `VisitController` 클래스 구현
     `POST /api/visits` → 방문 정보 저장 (**201 Created 및 Location** 헤더 반환)
    `GET /api/visits` → 모든 방문 기록 조회
  - `VisitDto` 를 이용한 요청/응답 매핑 로직 연결

## 관련 Issue
- closes #13  

## 체크리스트
- [x] `./gradlew bootRun` 시 컴파일 및 서버 기동 정상 확인
- [x] `POST /api/visits` 요청 시 **HTTP 201 Created** 응답 확인
- [x] 응답 바디에 생성된 `VisitDto` 반환 확인
- [x] `GET /api/visits` 요청 시 저장된 방문 기록 리스트 정상 반환
- [x] DBeaver 등 DB 클라이언트에서 visit 테이블에 데이터 저장 확인